### PR TITLE
feat: full file path resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## [Unreleased]
+
+- Added support for drag and drop of files and folders. [@ayatkyo](https://github.com/ayatkyo) in [#1](https://github.com/wailsapp/go-webview2/pull/1).

--- a/pkg/edge/ICoreWebView2File.go
+++ b/pkg/edge/ICoreWebView2File.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package edge
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type _ICoreWebView2FileVtbl struct {
+	_IUnknownVtbl
+	GetPath ComProc
+}
+
+type ICoreWebView2File struct {
+	vtbl *_ICoreWebView2FileVtbl
+}
+
+func (i *ICoreWebView2File) AddRef() uintptr {
+	return i.AddRef()
+}
+
+func (i *ICoreWebView2File) GetPath() (string, error) {
+	var err error
+	var _path *uint16
+	_, _, err = i.vtbl.GetPath.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&_path)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return "", err
+	}
+
+	path := windows.UTF16PtrToString(_path)
+	windows.CoTaskMemFree(unsafe.Pointer(_path))
+	return path, nil
+}

--- a/pkg/edge/ICoreWebView2ObjectCollectionView.go
+++ b/pkg/edge/ICoreWebView2ObjectCollectionView.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package edge
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type _ICoreWebView2ObjectCollectionViewVtbl struct {
+	_IUnknownVtbl
+	GetCount        ComProc
+	GetValueAtIndex ComProc
+}
+
+type ICoreWebView2ObjectCollectionView struct {
+	vtbl *_ICoreWebView2ObjectCollectionViewVtbl
+}
+
+func (i *ICoreWebView2ObjectCollectionView) GetCount() (*uint32, error) {
+	var err error
+	var value *uint32
+	_, _, err = i.vtbl.GetCount.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&value)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return nil, err
+	}
+	return value, nil
+}
+
+func (i *ICoreWebView2ObjectCollectionView) GetValueAtIndex(index uint32) (*_IUnknownVtbl, error) {
+	var err error
+	var value *_IUnknownVtbl
+	_, _, err = i.vtbl.GetValueAtIndex.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(index),
+		uintptr(unsafe.Pointer(&value)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return nil, err
+	}
+	return value, nil
+}

--- a/pkg/edge/ICoreWebView2WebMessageReceivedEventArgs.go
+++ b/pkg/edge/ICoreWebView2WebMessageReceivedEventArgs.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package edge
+
+type iCoreWebView2WebMessageReceivedEventArgsVtbl struct {
+	_IUnknownVtbl
+	GetSource                ComProc
+	GetWebMessageAsJSON      ComProc
+	TryGetWebMessageAsString ComProc
+}
+
+type iCoreWebView2WebMessageReceivedEventArgs struct {
+	vtbl *iCoreWebView2WebMessageReceivedEventArgsVtbl
+}

--- a/pkg/edge/ICoreWebView2WebMessageReceivedEventArgs.go
+++ b/pkg/edge/ICoreWebView2WebMessageReceivedEventArgs.go
@@ -2,13 +2,33 @@
 
 package edge
 
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
 type iCoreWebView2WebMessageReceivedEventArgsVtbl struct {
 	_IUnknownVtbl
 	GetSource                ComProc
 	GetWebMessageAsJSON      ComProc
 	TryGetWebMessageAsString ComProc
+	GetAdditionalObjects     ComProc
 }
 
 type iCoreWebView2WebMessageReceivedEventArgs struct {
 	vtbl *iCoreWebView2WebMessageReceivedEventArgsVtbl
+}
+
+func (i *iCoreWebView2WebMessageReceivedEventArgs) GetAdditionalObjects() (*ICoreWebView2ObjectCollectionView, error) {
+	var err error
+	var value *ICoreWebView2ObjectCollectionView
+	_, _, err = i.vtbl.GetAdditionalObjects.Call(
+		uintptr(unsafe.Pointer(i)),
+		uintptr(unsafe.Pointer(&value)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return nil, err
+	}
+	return value, nil
 }

--- a/pkg/edge/ICoreWebView2WebMessageReceivedEventArgs.go
+++ b/pkg/edge/ICoreWebView2WebMessageReceivedEventArgs.go
@@ -16,11 +16,11 @@ type iCoreWebView2WebMessageReceivedEventArgsVtbl struct {
 	GetAdditionalObjects     ComProc
 }
 
-type iCoreWebView2WebMessageReceivedEventArgs struct {
+type ICoreWebView2WebMessageReceivedEventArgs struct {
 	vtbl *iCoreWebView2WebMessageReceivedEventArgsVtbl
 }
 
-func (i *iCoreWebView2WebMessageReceivedEventArgs) GetAdditionalObjects() (*ICoreWebView2ObjectCollectionView, error) {
+func (i *ICoreWebView2WebMessageReceivedEventArgs) GetAdditionalObjects() (*ICoreWebView2ObjectCollectionView, error) {
 	var err error
 	var value *ICoreWebView2ObjectCollectionView
 	_, _, err = i.vtbl.GetAdditionalObjects.Call(

--- a/pkg/edge/ICoreWebView2WebMessageReceivedEventHandler.go
+++ b/pkg/edge/ICoreWebView2WebMessageReceivedEventHandler.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package edge
+
+type iCoreWebView2WebMessageReceivedEventHandlerVtbl struct {
+	_IUnknownVtbl
+	Invoke ComProc
+}
+
+type iCoreWebView2WebMessageReceivedEventHandler struct {
+	vtbl *iCoreWebView2WebMessageReceivedEventHandlerVtbl
+	impl iCoreWebView2WebMessageReceivedEventHandlerImpl
+}
+
+func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownQueryInterface(this *iCoreWebView2WebMessageReceivedEventHandler, refiid, object uintptr) uintptr {
+	return this.impl.QueryInterface(refiid, object)
+}
+
+func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownAddRef(this *iCoreWebView2WebMessageReceivedEventHandler) uintptr {
+	return this.impl.AddRef()
+}
+
+func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownRelease(this *iCoreWebView2WebMessageReceivedEventHandler) uintptr {
+	return this.impl.Release()
+}
+
+func _ICoreWebView2WebMessageReceivedEventHandlerInvoke(this *iCoreWebView2WebMessageReceivedEventHandler, sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr {
+	return this.impl.MessageReceived(sender, args)
+}
+
+type iCoreWebView2WebMessageReceivedEventHandlerImpl interface {
+	_IUnknownImpl
+	MessageReceived(sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr
+}
+
+var iCoreWebView2WebMessageReceivedEventHandlerFn = iCoreWebView2WebMessageReceivedEventHandlerVtbl{
+	_IUnknownVtbl{
+		NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerIUnknownQueryInterface),
+		NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerIUnknownAddRef),
+		NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerIUnknownRelease),
+	},
+	NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerInvoke),
+}
+
+func newICoreWebView2WebMessageReceivedEventHandler(impl iCoreWebView2WebMessageReceivedEventHandlerImpl) *iCoreWebView2WebMessageReceivedEventHandler {
+	return &iCoreWebView2WebMessageReceivedEventHandler{
+		vtbl: &iCoreWebView2WebMessageReceivedEventHandlerFn,
+		impl: impl,
+	}
+}

--- a/pkg/edge/ICoreWebView2WebMessageReceivedEventHandler.go
+++ b/pkg/edge/ICoreWebView2WebMessageReceivedEventHandler.go
@@ -24,13 +24,13 @@ func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownRelease(this *iCoreWebV
 	return this.impl.Release()
 }
 
-func _ICoreWebView2WebMessageReceivedEventHandlerInvoke(this *iCoreWebView2WebMessageReceivedEventHandler, sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr {
+func _ICoreWebView2WebMessageReceivedEventHandlerInvoke(this *iCoreWebView2WebMessageReceivedEventHandler, sender *ICoreWebView2, args *ICoreWebView2WebMessageReceivedEventArgs) uintptr {
 	return this.impl.MessageReceived(sender, args)
 }
 
 type iCoreWebView2WebMessageReceivedEventHandlerImpl interface {
 	_IUnknownImpl
-	MessageReceived(sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr
+	MessageReceived(sender *ICoreWebView2, args *ICoreWebView2WebMessageReceivedEventArgs) uintptr
 }
 
 var iCoreWebView2WebMessageReceivedEventHandlerFn = iCoreWebView2WebMessageReceivedEventHandlerVtbl{

--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -49,7 +49,7 @@ type Chromium struct {
 
 	// Callbacks
 	MessageCallback                      func(string)
-	MessageWithAdditionalObjectsCallback func(message string, sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs)
+	MessageWithAdditionalObjectsCallback func(message string, sender *ICoreWebView2, args *ICoreWebView2WebMessageReceivedEventArgs)
 	WebResourceRequestedCallback         func(request *ICoreWebView2WebResourceRequest, args *ICoreWebView2WebResourceRequestedEventArgs)
 	NavigationCompletedCallback          func(sender *ICoreWebView2, args *ICoreWebView2NavigationCompletedEventArgs)
 	ProcessFailedCallback                func(sender *ICoreWebView2, args *ICoreWebView2ProcessFailedEventArgs)
@@ -277,7 +277,7 @@ func (e *Chromium) CreateCoreWebView2ControllerCompleted(res uintptr, controller
 	return 0
 }
 
-func (e *Chromium) MessageReceived(sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr {
+func (e *Chromium) MessageReceived(sender *ICoreWebView2, args *ICoreWebView2WebMessageReceivedEventArgs) uintptr {
 	var _message *uint16
 	args.vtbl.TryGetWebMessageAsString.Call(
 		uintptr(unsafe.Pointer(args)),

--- a/pkg/edge/corewebview2.go
+++ b/pkg/edge/corewebview2.go
@@ -272,19 +272,6 @@ func (e *ICoreWebView2Environment) CreateWebResourceResponse(content []byte, sta
 
 }
 
-// ICoreWebView2WebMessageReceivedEventArgs
-
-type iCoreWebView2WebMessageReceivedEventArgsVtbl struct {
-	_IUnknownVtbl
-	GetSource                ComProc
-	GetWebMessageAsJSON      ComProc
-	TryGetWebMessageAsString ComProc
-}
-
-type iCoreWebView2WebMessageReceivedEventArgs struct {
-	vtbl *iCoreWebView2WebMessageReceivedEventArgsVtbl
-}
-
 // ICoreWebView2PermissionRequestedEventArgs
 
 type iCoreWebView2PermissionRequestedEventArgsVtbl struct {
@@ -346,55 +333,6 @@ var iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerFn = iCoreWebView2
 func newICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler(impl iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerImpl) *iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandler {
 	return &iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandler{
 		vtbl: &iCoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerFn,
-		impl: impl,
-	}
-}
-
-// ICoreWebView2WebMessageReceivedEventHandler
-
-type iCoreWebView2WebMessageReceivedEventHandlerImpl interface {
-	_IUnknownImpl
-	MessageReceived(sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr
-}
-
-type iCoreWebView2WebMessageReceivedEventHandlerVtbl struct {
-	_IUnknownVtbl
-	Invoke ComProc
-}
-
-type iCoreWebView2WebMessageReceivedEventHandler struct {
-	vtbl *iCoreWebView2WebMessageReceivedEventHandlerVtbl
-	impl iCoreWebView2WebMessageReceivedEventHandlerImpl
-}
-
-func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownQueryInterface(this *iCoreWebView2WebMessageReceivedEventHandler, refiid, object uintptr) uintptr {
-	return this.impl.QueryInterface(refiid, object)
-}
-
-func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownAddRef(this *iCoreWebView2WebMessageReceivedEventHandler) uintptr {
-	return this.impl.AddRef()
-}
-
-func _ICoreWebView2WebMessageReceivedEventHandlerIUnknownRelease(this *iCoreWebView2WebMessageReceivedEventHandler) uintptr {
-	return this.impl.Release()
-}
-
-func _ICoreWebView2WebMessageReceivedEventHandlerInvoke(this *iCoreWebView2WebMessageReceivedEventHandler, sender *ICoreWebView2, args *iCoreWebView2WebMessageReceivedEventArgs) uintptr {
-	return this.impl.MessageReceived(sender, args)
-}
-
-var iCoreWebView2WebMessageReceivedEventHandlerFn = iCoreWebView2WebMessageReceivedEventHandlerVtbl{
-	_IUnknownVtbl{
-		NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerIUnknownQueryInterface),
-		NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerIUnknownAddRef),
-		NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerIUnknownRelease),
-	},
-	NewComProc(_ICoreWebView2WebMessageReceivedEventHandlerInvoke),
-}
-
-func newICoreWebView2WebMessageReceivedEventHandler(impl iCoreWebView2WebMessageReceivedEventHandlerImpl) *iCoreWebView2WebMessageReceivedEventHandler {
-	return &iCoreWebView2WebMessageReceivedEventHandler{
-		vtbl: &iCoreWebView2WebMessageReceivedEventHandlerFn,
 		impl: impl,
 	}
 }


### PR DESCRIPTION
This PR is for resolving the full file path of js `File`.

This feature is only supported on webview2 >= 1.0.1774.30. [Link](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs2?view=webview2-1.0.1823.32#applies-to).

Implementation base on: https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2file?view=webview2-1.0.1823.32