### PR TITLE
GetPhysicalKeyStatus use correct COM struct definition

### DIFF
--- a/pkg/edge/COREWEBVIEW2_PHYSICAL_KEY_STATUS.go
+++ b/pkg/edge/COREWEBVIEW2_PHYSICAL_KEY_STATUS.go
@@ -10,3 +10,14 @@ type COREWEBVIEW2_PHYSICAL_KEY_STATUS struct {
 	WasKeyDown    bool
 	IsKeyReleased bool
 }
+
+// Bools need to be int32 in the native struct otherwise we end up in memory corruption. Using the internal
+// struct is a hacky way so we don't break the public interface.
+type internal_COREWEBVIEW2_PHYSICAL_KEY_STATUS struct {
+	RepeatCount   uint32
+	ScanCode      uint32
+	IsExtendedKey int32
+	IsMenuKeyDown int32
+	WasKeyDown    int32
+	IsKeyReleased int32
+}

--- a/pkg/edge/ICoreWebView2AcceleratorKeyPressedEventArgs.go
+++ b/pkg/edge/ICoreWebView2AcceleratorKeyPressedEventArgs.go
@@ -54,7 +54,7 @@ func (i *ICoreWebView2AcceleratorKeyPressedEventArgs) GetVirtualKey() (uint, err
 
 func (i *ICoreWebView2AcceleratorKeyPressedEventArgs) GetPhysicalKeyStatus() (COREWEBVIEW2_PHYSICAL_KEY_STATUS, error) {
 	var err error
-	var physicalKeyStatus COREWEBVIEW2_PHYSICAL_KEY_STATUS
+	var physicalKeyStatus internal_COREWEBVIEW2_PHYSICAL_KEY_STATUS
 	_, _, err = i.vtbl.GetPhysicalKeyStatus.Call(
 		uintptr(unsafe.Pointer(i)),
 		uintptr(unsafe.Pointer(&physicalKeyStatus)),
@@ -62,7 +62,14 @@ func (i *ICoreWebView2AcceleratorKeyPressedEventArgs) GetPhysicalKeyStatus() (CO
 	if err != windows.ERROR_SUCCESS {
 		return COREWEBVIEW2_PHYSICAL_KEY_STATUS{}, err
 	}
-	return physicalKeyStatus, nil
+	return COREWEBVIEW2_PHYSICAL_KEY_STATUS{
+		RepeatCount:   physicalKeyStatus.RepeatCount,
+		ScanCode:      physicalKeyStatus.ScanCode,
+		IsExtendedKey: physicalKeyStatus.IsExtendedKey != 0,
+		IsMenuKeyDown: physicalKeyStatus.IsMenuKeyDown != 0,
+		WasKeyDown:    physicalKeyStatus.WasKeyDown != 0,
+		IsKeyReleased: physicalKeyStatus.IsKeyReleased != 0,
+	}, nil
 }
 
 func (i *ICoreWebView2AcceleratorKeyPressedEventArgs) PutHandled(handled bool) error {


### PR DESCRIPTION
This fixes some memory corruptions during Accelerator callback handling