### PR TITLE
Fix overlapped I/O error when executing long JS scripts

### DIFF
--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -255,7 +255,7 @@ func (e *Chromium) Eval(script string) {
 		uintptr(unsafe.Pointer(_script)),
 		0,
 	)
-	if err != nil && !errors.Is(err, windows.ERROR_SUCCESS) {
+	if err != nil && !errors.Is(err, windows.ERROR_SUCCESS) && !errors.Is(err, windows.ERROR_IO_PENDING) {
 		e.errorCallback(err)
 	}
 }


### PR DESCRIPTION
After reviewing the historical code, it seems that this issue has always been present. The reason it wasn't noticed earlier is that previous versions of the code did not include proper error handling, which allowed the "Overlapped I/O operation is in progress" error to be overlooked(that's why `v1.0.10` works well).

This error is not actually a critical one, and as such, this PR resolves this issue #12  by ignoring the "Overlapped I/O operation is in progress" error.