### PR TITLE
Resolve the panic occurs when sending long data from JS to Go

### DIFF
--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -423,7 +423,7 @@ func (e *Chromium) MessageReceived(sender *ICoreWebView2, args *ICoreWebView2Web
 		uintptr(unsafe.Pointer(sender)),
 		uintptr(unsafe.Pointer(_message)),
 	)
-	if err != nil && !errors.Is(err, windows.ERROR_SUCCESS) {
+	if err != nil && !errors.Is(err, windows.ERROR_SUCCESS) && !errors.Is(err, windows.ERROR_IO_PENDING) {
 		e.errorCallback(err)
 	}
 	windows.CoTaskMemFree(unsafe.Pointer(_message))


### PR DESCRIPTION
This PR fixes issue-#16.

Related discussions: 
https://github.com/wailsapp/go-webview2/issues/12#issuecomment-2326955801
https://github.com/wailsapp/go-webview2/issues/16#issuecomment-2327682410