### PR TITLE
fix: com error handling

### DIFF
--- a/pkg/edge/ICoreWebView2HttpRequestHeaders.go
+++ b/pkg/edge/ICoreWebView2HttpRequestHeaders.go
@@ -27,16 +27,16 @@ type ICoreWebView2HttpRequestHeaders struct {
 	vtbl *_ICoreWebView2HttpRequestHeadersVtbl
 }
 
-func (i *ICoreWebView2HttpRequestHeaders) AddRef() uint32 {
-	ret, _, _ := i.vtbl.AddRef.Call(uintptr(unsafe.Pointer(i)))
+func (i *ICoreWebView2HttpRequestHeaders) AddRef() error {
+	i.vtbl.AddRef.Call(uintptr(unsafe.Pointer(i)))
 
-	return uint32(ret)
+	return nil
 }
 
-func (i *ICoreWebView2HttpRequestHeaders) Release() uint32 {
-	ret, _, _ := i.vtbl.Release.Call(uintptr(unsafe.Pointer(i)))
+func (i *ICoreWebView2HttpRequestHeaders) Release() error {
+	i.vtbl.Release.Call(uintptr(unsafe.Pointer(i)))
 
-	return uint32(ret)
+	return nil
 }
 
 // GetHeader returns the value of the specified header. If the header is not found

--- a/pkg/edge/ICoreWebView2ObjectCollectionView.go
+++ b/pkg/edge/ICoreWebView2ObjectCollectionView.go
@@ -18,16 +18,16 @@ type ICoreWebView2ObjectCollectionView struct {
 	vtbl *_ICoreWebView2ObjectCollectionViewVtbl
 }
 
-func (i *ICoreWebView2ObjectCollectionView) AddRef() uint32 {
-	ret, _, _ := i.vtbl.AddRef.Call(uintptr(unsafe.Pointer(i)))
+func (i *ICoreWebView2ObjectCollectionView) AddRef() error {
+	i.vtbl.AddRef.Call(uintptr(unsafe.Pointer(i)))
 
-	return uint32(ret)
+	return nil
 }
 
-func (i *ICoreWebView2ObjectCollectionView) Release() uint32 {
-	ret, _, _ := i.vtbl.Release.Call(uintptr(unsafe.Pointer(i)))
+func (i *ICoreWebView2ObjectCollectionView) Release() error {
+	i.vtbl.Release.Call(uintptr(unsafe.Pointer(i)))
 
-	return uint32(ret)
+	return nil
 }
 
 func (i *ICoreWebView2ObjectCollectionView) GetCount() (uint32, error) {


### PR DESCRIPTION
- __fix v3 build error__: v3 expects errors at some function too..

As @stffabi said in this [comment](https://github.com/wailsapp/wails/issues/3931#issuecomment-2519498697), instead of blindly ignoring last error value from proc.call, some more decisions would need to be made..
