### PR TITLE
Fix SetSize crash on Windows 32-bit

### DIFF
--- a/pkg/edge/chromium_386.go
+++ b/pkg/edge/chromium_386.go
@@ -5,6 +5,8 @@ package edge
 
 import (
 	"github.com/wailsapp/go-webview2/internal/w32"
+	"golang.org/x/sys/windows"
+	"unsafe"
 )
 
 func (e *Chromium) SetSize(bounds w32.Rect) {
@@ -12,8 +14,15 @@ func (e *Chromium) SetSize(bounds w32.Rect) {
 		return
 	}
 
-	err := e.controller.PutBounds(bounds)
-	if err != nil {
-		e.errorCallback(err)
+	hr, _, _ := e.controller.vtbl.PutBounds.Call(
+		uintptr(unsafe.Pointer(e.controller)),
+		uintptr(bounds.Left),
+		uintptr(bounds.Top),
+		uintptr(bounds.Right),
+		uintptr(bounds.Bottom),
+	)
+
+	if windows.Handle(hr) != windows.S_OK {
+		e.errorCallback(windows.Errno(hr))
 	}
 }


### PR DESCRIPTION
## Description
Fixes a crash in `SetSize` method for 32-bit Windows builds by replacing the high-level `PutBounds` call with a manual vtbl call approach, similar to the ARM64 implementation. 

## Changes
- Updated `chromium_386.go` to use direct COM vtbl calls
- Now uses correct 32-bit calling convention

## Testing
-  Confirmed crash is fixed on Wails 32-bit Windows builds (GOARCH=386) ✅

<img width="503" height="328" alt="image" src="https://github.com/user-attachments/assets/ca64c70a-f837-494d-9102-61e87465bd7b" />
