### PR TITLE
Fix PutShouldDetectMonitorScaleChanges method

### DIFF
--- a/pkg/edge/ICoreWebView2Controller3.go
+++ b/pkg/edge/ICoreWebView2Controller3.go
@@ -112,7 +112,7 @@ func (i *ICoreWebView2Controller3) PutShouldDetectMonitorScaleChanges(value bool
 
 	hr, _, _ := i.Vtbl.PutShouldDetectMonitorScaleChanges.Call(
 		uintptr(unsafe.Pointer(i)),
-		uintptr(unsafe.Pointer(&value)),
+		uintptr(boolToInt(value)),
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)

--- a/pkg/webview2/ICoreWebView2Controller3.go
+++ b/pkg/webview2/ICoreWebView2Controller3.go
@@ -84,10 +84,16 @@ func (i *ICoreWebView2Controller3) GetShouldDetectMonitorScaleChanges() (bool, e
 }
 
 func (i *ICoreWebView2Controller3) PutShouldDetectMonitorScaleChanges(value bool) error {
+	var intValue uintptr
+	if value {
+		intValue = 1
+	} else {
+		intValue = 0
+	}
 
 	hr, _, _ := i.Vtbl.PutShouldDetectMonitorScaleChanges.Call(
 		uintptr(unsafe.Pointer(i)),
-		uintptr(unsafe.Pointer(&value)),
+		intValue,
 	)
 	if windows.Handle(hr) != windows.S_OK {
 		return syscall.Errno(hr)


### PR DESCRIPTION
The PutShouldDetectMonitorScaleChanges method was incorrectly passing a pointer to a boolean value (uintptr(unsafe.Pointer(&value))) instead of converting the boolean to an integer value. COM methods expect boolean parameters to be passed as integer values (0 or 1), not as pointers.

This bug was causing COM calls to fail during WebView2 controller initialization, which triggered the error callback and caused applications to crash or fail to initialize properly. This manifested as:
- "Not enough memory resources are available" errors during drag-drop
- "WebView2Process failed with kind 1" errors
- Blank windows on Windows 10

The fix changes the parameter passing to use the correct pattern:
- pkg/edge: Use boolToInt(value) helper function
- pkg/webview2: Inline boolean-to-int conversion

This matches the pattern used in other boolean COM methods like PutIsVisible.