### PR TITLE
replace fmt with log for error and stack trace logging

### DIFF
--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -28,13 +28,13 @@ func globalErrorHandler(err error) {
 		return
 	}
 
-	fmt.Printf("[WebView2 Error] %v\n", err)
+	log.Printf("[WebView2 Error] %v\n", err)
 
 	stackBuf := make([]uintptr, 64)
 	stackSize := runtime.Callers(2, stackBuf)
 	frames := runtime.CallersFrames(stackBuf[:stackSize])
 
-	fmt.Println("\nStack trace:")
+	log.Printf("\nStack trace:")
 	stackIndex := 1
 	for {
 		frame, more := frames.Next()


### PR DESCRIPTION
This PR replaces fmt printing with structured logging for error and stack trace reporting.

On Windows, especially in real production applications started outside of a terminal, fmt.Println / fmt.Printf output is often not visible or accessible because there is no attached console. As a result, important error messages and stack traces can be completely lost.