### PR TITLE
Fix/completed handler pwstr result

### DIFF
--- a/pkg/webview2/ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler.go
+++ b/pkg/webview2/ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler.go
@@ -33,13 +33,13 @@ func ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandlerIUnknownRel
 	return this.impl.Release()
 }
 
-func ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandlerInvoke(this *ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler, errorCode uintptr, result string) uintptr {
+func ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandlerInvoke(this *ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler, errorCode uintptr, result *uint16) uintptr {
 	return this.impl.AddScriptToExecuteOnDocumentCreatedCompleted(errorCode, result)
 }
 
 type ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandlerImpl interface {
 	IUnknownImpl
-	AddScriptToExecuteOnDocumentCreatedCompleted(errorCode uintptr, result string) uintptr
+	AddScriptToExecuteOnDocumentCreatedCompleted(errorCode uintptr, result *uint16) uintptr
 }
 
 var ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandlerFn = ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandlerVtbl{

--- a/pkg/webview2/ICoreWebView2CallDevToolsProtocolMethodCompletedHandler.go
+++ b/pkg/webview2/ICoreWebView2CallDevToolsProtocolMethodCompletedHandler.go
@@ -33,13 +33,13 @@ func ICoreWebView2CallDevToolsProtocolMethodCompletedHandlerIUnknownRelease(this
 	return this.impl.Release()
 }
 
-func ICoreWebView2CallDevToolsProtocolMethodCompletedHandlerInvoke(this *ICoreWebView2CallDevToolsProtocolMethodCompletedHandler, errorCode uintptr, result string) uintptr {
+func ICoreWebView2CallDevToolsProtocolMethodCompletedHandlerInvoke(this *ICoreWebView2CallDevToolsProtocolMethodCompletedHandler, errorCode uintptr, result *uint16) uintptr {
 	return this.impl.CallDevToolsProtocolMethodCompleted(errorCode, result)
 }
 
 type ICoreWebView2CallDevToolsProtocolMethodCompletedHandlerImpl interface {
 	IUnknownImpl
-	CallDevToolsProtocolMethodCompleted(errorCode uintptr, result string) uintptr
+	CallDevToolsProtocolMethodCompleted(errorCode uintptr, result *uint16) uintptr
 }
 
 var ICoreWebView2CallDevToolsProtocolMethodCompletedHandlerFn = ICoreWebView2CallDevToolsProtocolMethodCompletedHandlerVtbl{

--- a/pkg/webview2/ICoreWebView2ExecuteScriptCompletedHandler.go
+++ b/pkg/webview2/ICoreWebView2ExecuteScriptCompletedHandler.go
@@ -33,13 +33,13 @@ func ICoreWebView2ExecuteScriptCompletedHandlerIUnknownRelease(this *ICoreWebVie
 	return this.impl.Release()
 }
 
-func ICoreWebView2ExecuteScriptCompletedHandlerInvoke(this *ICoreWebView2ExecuteScriptCompletedHandler, errorCode uintptr, result string) uintptr {
+func ICoreWebView2ExecuteScriptCompletedHandlerInvoke(this *ICoreWebView2ExecuteScriptCompletedHandler, errorCode uintptr, result *uint16) uintptr {
 	return this.impl.ExecuteScriptCompleted(errorCode, result)
 }
 
 type ICoreWebView2ExecuteScriptCompletedHandlerImpl interface {
 	IUnknownImpl
-	ExecuteScriptCompleted(errorCode uintptr, result string) uintptr
+	ExecuteScriptCompleted(errorCode uintptr, result *uint16) uintptr
 }
 
 var ICoreWebView2ExecuteScriptCompletedHandlerFn = ICoreWebView2ExecuteScriptCompletedHandlerVtbl{


### PR DESCRIPTION
Importing pkg/webview2 panics during package init on amd64:
    
        panic: compileCallback: argument size is larger than uintptr
          syscall.NewCallback(...)
          webview2.NewComProc(...)                              com.go:17
          webview2.init()  ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler.go:51
    
    Three CompletedHandler callbacks declare their result parameter as a Go
    string. syscall.NewCallback requires every argument to be no wider than a
    uintptr; a string is a 16-byte header, so it is rejected outright. These
    are LPCWSTR out-params, so the correct Go type is *uint16.
    
    Because the handler vtables are built in package-level var initialisers,
    this fires at init for any program that imports the package, regardless of
    whether these handlers are ever used -- so the package is unusable on
    amd64 as shipped. All three are fixed together for that reason: correcting
    only one moves the panic to the next.
    
    Affected:
      ICoreWebView2AddScriptToExecuteOnDocumentCreatedCompletedHandler
      ICoreWebView2ExecuteScriptCompletedHandler
      ICoreWebView2CallDevToolsProtocolMethodCompletedHandler
    
    This looks like a code-generator issue rather than three separate slips:
    all three map LPCWSTR to string for a *callback* parameter, which is safe
    for outbound calls and never valid inbound. A generator-level fix may
    touch more files than these.
    
    Callers implementing these interfaces convert with
    windows.UTF16PtrToString(result).
    
    Verified: GOOS=windows GOARCH=amd64 go build ./... and go vet ./pkg/webview2/